### PR TITLE
support redis standalone mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ In addition to the sentinel's own capabilities, redis-operator can:
 * False delete automatic recovery
 * Persistence
 * Custom SecurityContext
+* Standalone Mode
 
 ## Quick Start
 
@@ -342,6 +343,25 @@ spec:
       sysctls:
       - name: net.core.somaxconn
         value: "1024"
+```
+
+#### Redis Standalone Mode
+
+If you only requires single node, non auto failover redis instance, You can deploy standalone redis instance, this will change headless service to normal.
+
+```
+apiVersion: redis.kun/v1beta1
+kind: RedisCluster
+metadata:
+  name: standalone
+spec:
+  size: 1
+```
+
+```
+# kubectl get svc redis-cluster-standalone
+
+redis-cluster-standalone  ClusterIP      172.31.254.96 
 ```
 
 ### Cleanup

--- a/deploy/crds/redis_v1beta1_rediscluster_crd.yaml
+++ b/deploy/crds/redis_v1beta1_rediscluster_crd.yaml
@@ -101,7 +101,7 @@ spec:
             size:
               format: int32
               type: integer
-              minimum: 3
+              minimum: 1
               maximum: 10
             storage:
               properties:

--- a/pkg/apis/redis/v1beta1/rediscluster_types.go
+++ b/pkg/apis/redis/v1beta1/rediscluster_types.go
@@ -45,6 +45,13 @@ type RedisCluster struct {
 	Status RedisClusterStatus `json:"status,omitempty"`
 }
 
+func (r *RedisCluster) Standalone() bool {
+	if r.Spec.Sentinel.Replicas == 0  {
+		return true
+	}
+	return false
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // RedisClusterList contains a list of RedisCluster

--- a/pkg/apis/redis/v1beta1/validate.go
+++ b/pkg/apis/redis/v1beta1/validate.go
@@ -30,13 +30,15 @@ func (r *RedisCluster) Validate() error {
 
 	if r.Spec.Size == 0 {
 		r.Spec.Size = defaultRedisNumber
-	} else if r.Spec.Size < defaultRedisNumber {
+	} else if r.Spec.Size < defaultRedisNumber && r.Spec.Size != 1 {
 		return errors.New("number of redis in spec is less than the minimum")
 	}
 
 	if r.Spec.Sentinel.Replicas == 0 {
-		r.Spec.Sentinel.Replicas = defaultSentinelNumber
-	} else if r.Spec.Sentinel.Replicas < defaultSentinelNumber {
+		if r.Spec.Size > 1 {
+				r.Spec.Sentinel.Replicas = defaultSentinelNumber
+		}
+	} else if r.Spec.Sentinel.Replicas < defaultSentinelNumber  {
 		return errors.New("number of sentinels in spec is less than the minimum")
 	}
 

--- a/pkg/controller/rediscluster/ensurer.go
+++ b/pkg/controller/rediscluster/ensurer.go
@@ -11,27 +11,32 @@ func (r *RedisClusterHandler) Ensure(rc *redisv1beta1.RedisCluster, labels map[s
 	if err := r.rcService.EnsureRedisService(rc, labels, or); err != nil {
 		return err
 	}
-	if err := r.rcService.EnsureSentinelService(rc, labels, or); err != nil {
-		return err
+	if !rc.Standalone()  {
+		if err := r.rcService.EnsureSentinelService(rc, labels, or); err != nil {
+			return err
+		}
+		if err := r.rcService.EnsureSentinelHeadlessService(rc, labels, or); err != nil {
+			return err
+		}
+		if err := r.rcService.EnsureSentinelConfigMap(rc, labels, or); err != nil {
+			return err
+		}
+		if err := r.rcService.EnsureSentinelProbeConfigMap(rc, labels, or); err != nil {
+			return err
+		}
 	}
-	if err := r.rcService.EnsureSentinelHeadlessService(rc, labels, or); err != nil {
-		return err
-	}
-	if err := r.rcService.EnsureSentinelConfigMap(rc, labels, or); err != nil {
-		return err
-	}
-	if err := r.rcService.EnsureSentinelProbeConfigMap(rc, labels, or); err != nil {
-		return err
-	}
+
 	if err := r.rcService.EnsureRedisShutdownConfigMap(rc, labels, or); err != nil {
 		return err
 	}
 	if err := r.rcService.EnsureRedisStatefulset(rc, labels, or); err != nil {
 		return err
 	}
-	if err := r.rcService.EnsureSentinelStatefulset(rc, labels, or); err != nil {
-		return err
+	if !rc.Standalone() {
+		if err := r.rcService.EnsureSentinelStatefulset(rc, labels, or); err != nil {
+			return err
+		}
 	}
-
 	return nil
 }
+

--- a/pkg/controller/service/generator.go
+++ b/pkg/controller/service/generator.go
@@ -56,6 +56,24 @@ func generateRedisService(rc *redisv1beta1.RedisCluster, labels map[string]strin
 
 	labels = util.MergeLabels(labels, generateSelectorLabels(util.RedisRoleName, rc.Name))
 	redisTargetPort := intstr.FromInt(6379)
+
+	spec := corev1.ServiceSpec{
+		Type: corev1.ServiceTypeClusterIP,
+		Ports: []corev1.ServicePort{
+			{
+				Port:       6379,
+				Protocol:   corev1.ProtocolTCP,
+				Name:       "redis",
+				TargetPort: redisTargetPort,
+			},
+		},
+		Selector: labels,
+	}
+
+	if !rc.Standalone() {
+		spec.ClusterIP = corev1.ClusterIPNone
+	}
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
@@ -63,19 +81,7 @@ func generateRedisService(rc *redisv1beta1.RedisCluster, labels map[string]strin
 			Labels:          labels,
 			OwnerReferences: ownerRefs,
 		},
-		Spec: corev1.ServiceSpec{
-			Type:      corev1.ServiceTypeClusterIP,
-			ClusterIP: corev1.ClusterIPNone,
-			Ports: []corev1.ServicePort{
-				{
-					Port:       6379,
-					Protocol:   corev1.ProtocolTCP,
-					Name:       "redis",
-					TargetPort: redisTargetPort,
-				},
-			},
-			Selector: labels,
-		},
+		Spec: spec,
 	}
 }
 
@@ -665,6 +671,12 @@ func getRedisCommand(rc *redisv1beta1.RedisCluster) []string {
 		"--tcp-keepalive 60",
 		"--save 900 1",
 		"--save 300 10",
+	}
+
+	if rc.Standalone() {
+		cmds = []string{
+			"redis-server",
+		}
 	}
 
 	if rc.Spec.Password != "" {


### PR DESCRIPTION
Hi, I'm building Redis-PaaS build on this project, this project and Redis-cluster-operator cover most of my needs.
but sometimes, some application don't require HA & sharding, standalone is enough

many of the features of this project (online config, persistent) are useful, I wanted to provide Redis standalone support, In the standalone mode, headless services and sentries are not created, everything else compatible with the original API.

just need to configure `spec.size` to 1, it’s working in my environment, Can you merge this PR?